### PR TITLE
ci: fix Hugo Pages workflow

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -21,7 +21,6 @@ concurrency:
 defaults:
   run:
     shell: bash
-    working-directory: docs
 
 jobs:
   build:
@@ -35,19 +34,19 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      - name: Install Hugo CLI
-        run: |
-          wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
-          && sudo dpkg -i ${{ runner.temp }}/hugo.deb
+      - name: Setup Hugo
+        uses: actions/setup-hugo@v3
+        with:
+          hugo-version: ${{ env.HUGO_VERSION }}
+          extended: true
 
-      - name: Install Dart Sass
-        run: sudo snap install dart-sass
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v4
 
       - name: Install Node.js dependencies
         run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
+        working-directory: docs
 
       - name: Build with Hugo
         env:
@@ -58,6 +57,7 @@ jobs:
             --gc \
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/"
+        working-directory: docs
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
- Remove global working-directory to avoid early CWD errors\n- Use actions/setup-hugo@v3 (extended) instead of wget/dpkg\n- Drop snap-based Dart Sass install\n- Set per-step working-directory for npm and hugo build\n\nThis should fix the Pages deploy failures (seen in runs 17392440832 and 17392423494).